### PR TITLE
Fix Fleet Go toolchain pin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,9 @@
     nixpkgs,
     ...
   }: let
+    lib = nixpkgs.lib;
     forAllSystems =
-      nixpkgs.lib.genAttrs
+      lib.genAttrs
       [
         "aarch64-linux"
         "i686-linux"
@@ -19,6 +20,12 @@
         "aarch64-darwin"
         "x86_64-darwin"
       ];
+    requiredGoVersionForOrbit = system: let
+      src = self.packages.${system}.orbit.src;
+      goModLines = lib.splitString "\n" (builtins.readFile (src + "/go.mod"));
+      goVersionLine = builtins.head (builtins.filter (line: lib.hasPrefix "go " line) goModLines);
+    in
+      lib.removePrefix "go " goVersionLine;
   in {
     packages = forAllSystems (
       system:
@@ -27,7 +34,23 @@
         }
     );
 
-    checks = forAllSystems (system: self.packages.${system});
+    checks = forAllSystems (system:
+      self.packages.${system}
+      // {
+        orbit-go-version = let
+          pkgs = nixpkgs.legacyPackages.${system};
+          requiredVersion = requiredGoVersionForOrbit system;
+          selectedVersion = pkgs.go_1_26.version;
+        in
+          assert lib.assertMsg (lib.versionAtLeast selectedVersion requiredVersion)
+          "fleet orbit requires Go ${requiredVersion}, but pinned nixpkgs provides ${selectedVersion}";
+          pkgs.runCommand "orbit-go-version" {
+            requiredVersion = requiredVersion;
+            selectedVersion = selectedVersion;
+          } ''
+            touch "$out"
+          '';
+      });
 
     nixosModules.fleet-nixos = import ./modules {
       fleetPackages = self.packages;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,5 @@
 {pkgs ? import <nixpkgs> {}}: let
+  buildGoModule = pkgs.buildGo126Module;
   patchFiles = builtins.attrNames (builtins.readDir ../patches);
   orbitPatchFiles = builtins.filter (name: builtins.match "[0-9][0-9][0-9][0-9]-.*\\.patch" name != null) patchFiles;
   orbitPatches = builtins.map (name: ../patches + "/${name}") (builtins.sort builtins.lessThan orbitPatchFiles);
@@ -26,7 +27,7 @@
     "-X=github.com/fleetdm/fleet/v4/orbit/pkg/build.Date=${date}"
   ];
 in {
-  orbit = pkgs.buildGoModule {
+  orbit = buildGoModule {
     pname = "fleet-orbit";
     inherit
       version
@@ -36,7 +37,10 @@ in {
       ldflags
       ;
 
-    env.CGO_ENABLED = "1";
+    env = {
+      CGO_ENABLED = "1";
+      GOTOOLCHAIN = "local";
+    };
     subPackages = ["orbit/cmd/orbit"];
 
     passthru.updateScript = ../update.sh;
@@ -49,7 +53,7 @@ in {
     patches = orbitPatches;
   };
 
-  fleet-desktop = pkgs.buildGoModule {
+  fleet-desktop = buildGoModule {
     pname = "fleet-desktop";
     inherit
       version
@@ -59,7 +63,10 @@ in {
       ldflags
       ;
 
-    env.CGO_ENABLED = "1";
+    env = {
+      CGO_ENABLED = "1";
+      GOTOOLCHAIN = "local";
+    };
     subPackages = ["orbit/cmd/desktop"];
 
     passthru.updateScript = ../update.sh;


### PR DESCRIPTION
- bump pinned nixpkgs so Fleet builds with Go 1.26.4
- make the Go builder explicit for Orbit packages
- add a flake check that fails clearly when Fleet's go.mod requires a newer Go than pinned nixpkgs provides